### PR TITLE
update: use cookiecutter-brightwaylib 0.1.2

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include ecospolder/VERSION

--- a/ecospolder/__init__.py
+++ b/ecospolder/__init__.py
@@ -1,8 +1,8 @@
-from pathlib import Path
+import importlib.metadata
 from typing import Union
 
 
-def get_version() -> tuple:
+def get_version_tuple() -> tuple:
     def as_integer(x: str) -> Union[int, str]:
         try:
             return int(x)
@@ -11,8 +11,8 @@ def get_version() -> tuple:
 
     return tuple(
         as_integer(v)
-        for v in open(Path(__file__).parent / "VERSION").read().strip().split(".")
+        for v in importlib.metadata.version("ecospolder").strip().split(".")
     )
 
 
-__version__ = get_version()
+__version__ = get_version_tuple()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from click.testing import CliRunner
 
 from ecospolder import cli
 
+
 @pytest.fixture
 def runner() -> CliRunner:
     """Fixture for invoking command-line interfaces."""

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,6 @@
+import ecospolder
+
+
+def test_version_tuple():
+    version_t = ecospolder.__version__
+    assert isinstance(version_t, tuple)


### PR DESCRIPTION
+ include VERSION file in manifest
+ add test to verify that __version__ is a tuple